### PR TITLE
Add support for include_directive in C

### DIFF
--- a/tests/test_c_analyzer.py
+++ b/tests/test_c_analyzer.py
@@ -60,3 +60,10 @@ class Test_C_Analyzer(unittest.TestCase):
         self.assertIn('add', callers)
         self.assertIn('main', callers)
 
+        # Test for include_directive edge creation
+        included_file = g.get_file('', 'myheader.h', '.h')
+        self.assertIsNotNone(included_file)
+
+        includes = g.get_neighbors([f.id], rel='INCLUDES')
+        included_files = [node['properties']['name'] for node in includes['nodes']]
+        self.assertIn('myheader.h', included_files)


### PR DESCRIPTION
Fixes #46

Add support for processing `include_directive` in C files.

* **api/analyzers/c/analyzer.py**
  - Add `process_include_directive` method to handle `include_directive` nodes and create edges between files.
  - Modify `first_pass` method to process `include_directive` nodes and create edges between files.

* **tests/test_c_analyzer.py**
  - Add test case to verify the creation of edges between files for `include_directive`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FalkorDB/code-graph-backend/issues/46?shareId=XXXX-XXXX-XXXX-XXXX).