### PR TITLE
fix: upgrade dependencies to resolve Dependabot security alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{name = "Roi Lipman", email = "roilipman@gmail.com"}]
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
-    "graphrag-sdk>=0.8.1,<0.9.0",
+    "graphrag-sdk>=0.8.2,<0.9.0",
     "tree-sitter>=0.25.2,<0.26.0",
     "validators>=0.35.0,<0.36.0",
     "falkordb>=1.1.3,<2.0.0",
@@ -25,6 +25,12 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=9.0.2,<10.0.0",
+]
+
+[tool.uv]
+override-dependencies = [
+    "requests>=2.32.4",
+    "pypdf>=6.7.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.12, <3.14"
 
+[manifest]
+overrides = [
+    { name = "pypdf", specifier = ">=6.7.1" },
+    { name = "requests", specifier = ">=2.32.4" },
+]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -277,7 +283,7 @@ test = [
 requires-dist = [
     { name = "falkordb", specifier = ">=1.1.3,<2.0.0" },
     { name = "flask", specifier = ">=3.1.0,<4.0.0" },
-    { name = "graphrag-sdk", specifier = ">=0.8.1,<0.9.0" },
+    { name = "graphrag-sdk", specifier = ">=0.8.2,<0.9.0" },
     { name = "javatools", specifier = ">=1.6.0,<2.0.0" },
     { name = "multilspy", git = "https://github.com/AviAvni/multilspy.git?rev=python-init-params" },
     { name = "pygit2", specifier = ">=1.17.0,<2.0.0" },
@@ -403,7 +409,7 @@ wheels = [
 
 [[package]]
 name = "flask"
-version = "3.1.2"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
@@ -413,9 +419,9 @@ dependencies = [
     { name = "markupsafe" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/6d/cfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab/flask-3.1.2.tar.gz", hash = "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87", size = 720160, upload-time = "2025-08-19T21:03:21.205Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/f9/7f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd/flask-3.1.2-py3-none-any.whl", hash = "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c", size = 103308, upload-time = "2025-08-19T21:03:19.499Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -486,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "graphrag-sdk"
-version = "0.8.1"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -502,9 +508,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/34/eba77fb2d56107a9f4d07647c2bdc227e9a23ba2bac75ef4fddfc1ad15b6/graphrag_sdk-0.8.1.tar.gz", hash = "sha256:285d43a450bf27f2c737025fbf6277b05f097743b585192ec72086386d2fb904", size = 57790, upload-time = "2025-09-29T09:52:12.509Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/7d/10caf397a39311b5bb53b715d3fec9745f3e3ff39793914d5cf308d83291/graphrag_sdk-0.8.2.tar.gz", hash = "sha256:5d9d275e1b1bc1128eb56233a07ac4a7324d95430057164629da23948c4b4b69", size = 61476, upload-time = "2026-01-15T13:28:13.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/4b/5ff07312214e2d84aa245fe3980b6c156549136f36d1868c861013957895/graphrag_sdk-0.8.1-py3-none-any.whl", hash = "sha256:6bf1e1e41a4c7bb30fdd8c156af61de5f324ff9afb1908c587ca58657e0e0be2", size = 83540, upload-time = "2026-01-15T13:13:41.457Z" },
+    { url = "https://files.pythonhosted.org/packages/59/10/ea2845cab0288f962ee709ccb066f1476d2251e12feaa5262adb62311ec6/graphrag_sdk-0.8.2-py3-none-any.whl", hash = "sha256:f77a0addd08c13f89bbb87cd3b9a432729e1808bcabf2adeef79d8df3897e0e7", size = 83541, upload-time = "2026-01-15T13:28:12.118Z" },
 ]
 
 [[package]]
@@ -1176,11 +1182,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "5.9.0"
+version = "6.7.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/3a/584b97a228950ed85aec97c811c68473d9b8d149e6a8c155668287cf1a28/pypdf-5.9.0.tar.gz", hash = "sha256:30f67a614d558e495e1fbb157ba58c1de91ffc1718f5e0dfeb82a029233890a1", size = 5035118, upload-time = "2025-07-27T14:04:52.364Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b2/335465d6cff28a772ace8a58beb168f125c2e1d8f7a31527da180f4d89a1/pypdf-6.7.2.tar.gz", hash = "sha256:82a1a48de500ceea59a52a7d979f5095927ef802e4e4fac25ab862a73468acbb", size = 5302986, upload-time = "2026-02-22T11:33:30.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/d9/6cff57c80a6963e7dd183bf09e9f21604a77716644b1e580e97b259f7612/pypdf-5.9.0-py3-none-any.whl", hash = "sha256:be10a4c54202f46d9daceaa8788be07aa8cd5ea8c25c529c50dd509206382c35", size = 313193, upload-time = "2025-07-27T14:04:50.53Z" },
+    { url = "https://files.pythonhosted.org/packages/df/df/38b06d6e74646a4281856920a11efb431559bdeb643bf1e192bff5e29082/pypdf-6.7.2-py3-none-any.whl", hash = "sha256:331b63cd66f63138f152a700565b3e0cebdf4ec8bec3b7594b2522418782f1f3", size = 331245, upload-time = "2026-02-22T11:33:29.204Z" },
 ]
 
 [[package]]
@@ -1341,7 +1347,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1349,9 +1355,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload-time = "2024-05-29T15:37:47.027Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
 ]
 
 [[package]]
@@ -1672,14 +1678,14 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.5"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67", size = 864754, upload-time = "2026-01-08T17:49:23.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25", size = 864736, upload-time = "2026-02-19T15:17:18.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc", size = 225025, upload-time = "2026-01-08T17:49:21.859Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131", size = 225166, upload-time = "2026-02-19T15:17:17.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Upgrades vulnerable dependencies to resolve open Dependabot security alerts.

### Updated packages

| Package | Before | After | Severity | CVE/Issue |
|---------|--------|-------|----------|-----------|
| **flask** | 3.1.2 | 3.1.3 | Low | Session `Vary: Cookie` header fix |
| **werkzeug** | 3.1.5 | 3.1.6 | Medium | `safe_join()` Windows device names |
| **pypdf** | 5.9.0 | 6.7.2 | Medium | Multiple DoS/infinite loop fixes |
| **requests** | 2.32.3 | 2.32.5 | Medium | `.netrc` credential leak |
| **graphrag-sdk** | 0.8.1 | 0.8.2 | — | Minor update |

### Notes

- `pypdf` and `requests` required `[tool.uv] override-dependencies` because upstream packages pin them:
  - `graphrag-sdk` pins `pypdf<6.0.0`
  - `multilspy` pins `requests==2.32.3`
- The pypdf 5→6 major bump is safe — graphrag-sdk only uses `PdfReader.extract_text()`, which is unchanged.
- `urllib3` (2.6.3) and `filelock` (3.20.3) were already at patched versions.

Resolves Dependabot alerts: #85, #87, #89, #91, #92, #93, #94, #95, #96, #97, #98, #99, #100, #101, #102, #103, #104, #105, #106, #107, #108, #109, #110, #111, #112, #113